### PR TITLE
Add minimal deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["resources" "src"]
+ :deps {org.clojure/clojure {:mvn/version "1.10.1"}
+        de.siegmar/fastcsv {:mvn/version "1.0.3"}
+        com.ibm.icu/icu4j {:mvn/version "65.1"}}}


### PR DESCRIPTION
I had to add a deps.edn file here in order to get transitive dependencies loaded when I use this library in my own deps.edn-based project.