### PR TITLE
Allow Reader in addition to String and java.io.File

### DIFF
--- a/src/meta_csv/core.cljc
+++ b/src/meta_csv/core.cljc
@@ -637,6 +637,7 @@
                               opts
                               (do
                                 (when-not (or (instance? String uri)
+                                              (instance? Reader uri)
                                               (instance? java.io.File uri))
                                   (throw (ex-info "Cannot guess the specs of inputs that are neither String path nor File" {:uri uri})))
                                 (guess-spec uri opts))))

--- a/src/meta_csv/core.cljc
+++ b/src/meta_csv/core.cljc
@@ -638,6 +638,7 @@
                               (do
                                 (when-not (or (instance? String uri)
                                               (instance? Reader uri)
+                                              (instance? java.net.URL uri)
                                               (instance? java.io.File uri))
                                   (throw (ex-info "Cannot guess the specs of inputs that are neither String path nor File" {:uri uri})))
                                 (guess-spec uri opts))))


### PR DESCRIPTION
Per `read-csv`'s docstring, parameter `uri` should be able to be a Reader such as from `clojure.java.io/reader`. This PR makes that possible. My use case is something like:

```clojure
(with-open [rdr (io/reader (io/resource "iris.csv"))]
  (doall (csv/read-csv rdr {:fields [:sepal-length :sepal-width
                                     :petal-length :petal-width
                                     :species]})))
```
Ideally meta-csv would accept `java.net.URL` so that the resource could be read directly, but that isn't currently listed as an acceptable parameter. But adding `(instance? java.net.URL uri)` to this `or` would actually solve my use case more directly.

(I did not look into InputStreams but there may be a similar issue there.)